### PR TITLE
adjusted fontSize for all error messages to be 18px

### DIFF
--- a/client/src/components/form/ErrorMessage/ErrorMessage.tsx
+++ b/client/src/components/form/ErrorMessage/ErrorMessage.tsx
@@ -6,7 +6,9 @@ interface ErrorMessageProps {
 }
 
 const ErrorMessage: FC<ErrorMessageProps> = ({ children }) => (
-  <Box color="#FFB7C4">{children}</Box>
+  <Box sx={{ fontSize: 18 }} color="#FFB7C4">
+    {children}
+  </Box>
 );
 
 export default ErrorMessage;

--- a/client/src/components/form/FormControl/FormControl.tsx
+++ b/client/src/components/form/FormControl/FormControl.tsx
@@ -39,7 +39,12 @@ const FormControl: FC<FormControlInputProps> = ({
         <FormLabel htmlFor={id}>{label}</FormLabel>
       </Box>
       {children}
-      <FormHelperText id={helperTextId} sx={{ margin: '-10px 0 0' }}>{!!error && helperText}</FormHelperText>
+      <FormHelperText
+        id={helperTextId}
+        sx={{ margin: '-10px 0 0', fontSize: 18 }}
+      >
+        {!!error && helperText}
+      </FormHelperText>
     </Box>
   </MuiFormControl>
 );


### PR DESCRIPTION
![Screenshot 2023-11-22 at 8 18 35 AM](https://github.com/cubeca/cube_ui/assets/6579286/dfc4c5d4-7ea2-4db0-ac00-c851ab9d3afc)
