### PR TITLE
make it so only the first Artist field is required

### DIFF
--- a/client/src/pages/Upload/components/Screens/Tags.tsx
+++ b/client/src/pages/Upload/components/Screens/Tags.tsx
@@ -220,6 +220,7 @@ const Tags = ({ control }: any) => {
                 name={`artistName${index}`}
                 fullWidth
                 placeholder={t('Name (required)')}
+                rules={{ required: index === 0 }}
               />
             </Grid>
             <Grid xs={12} sm={4}>


### PR DESCRIPTION
if a user adds another, the page will still allow them to progress to the next screen.  I also experimented with adding a delete button but there isn't a lot of room available based on the way the MUI Grid is configured/styled.