### PR TITLE
aria and visual access updates to Search Page & Nav Bar

### DIFF
--- a/client/src/components/ContentCard/ContentCard.tsx
+++ b/client/src/components/ContentCard/ContentCard.tsx
@@ -59,31 +59,29 @@ const ContentCard: FC<ContentCardProps> = ({
           }}
           aria-label={coverImageAltText}
         >
-          <span role="img" aria-label={coverImageAltText}></span>
         </s.Thumbnail>
-        <div className="types"></div>
 
         <s.Data direction="row" alignItems="space-between">
-          <Typography component="div" className="title">
+          <Typography component="h4" className="title">
             {title}
           </Typography>
           <div className="types">
             {icon === 'video' ? (
-              <PlayArrowIcon fontSize="small" />
+              <PlayArrowIcon fontSize="small" titleAccess="Video Icon"/>
             ) : icon === 'audio' ? (
-              <VolumeUpIcon fontSize="small" />
+              <VolumeUpIcon fontSize="small" titleAccess="Audio Icon"/>
             ) : icon === 'pdf' ? (
-              <MenuBookIcon fontSize="small" />
+              <MenuBookIcon fontSize="small" titleAccess="PDF Icon"/>
             ) : icon === 'link' ? (
-              <LinkIcon fontSize="small" />
+              <LinkIcon fontSize="small" titleAccess="Linked Page Icon"/>
             ) : icon === 'playlist' ? (
-              <ListItemIcon fontSize="small" />
+              <ListItemIcon fontSize="small" titleAccess="Playlist Icon" aria-label="Playlist Icon"/>
             ) : icon === 'document' ? (
-              <DocIcon fontSize="small" />
+              <DocIcon fontSize="small" titleAccess="Word Doc Icon"/>
             ) : (
               <></>
             )}
-            {hasSignLanguage && <SignLanguageIcon fontSize="small" />}
+            {hasSignLanguage && <SignLanguageIcon fontSize="small" titleAccess="Sign Language Icon"/>}
           </div>
         </s.Data>
       </Link>

--- a/client/src/components/heroCTA/HeroCTA.tsx
+++ b/client/src/components/heroCTA/HeroCTA.tsx
@@ -27,11 +27,12 @@ const HeroCTA: FC<HeroCtaProps> = ({
         {title}
       </Typography>
       <Typography component="p" variant="body1" sx={{ color: '#2F4048' }}>
-        {text}<span>{frenchText}</span>
+        {text}<span aria-label="French translation">{frenchText}</span>
       </Typography>
     </s.CTAContent>
-    <s.CTAVideo>
+    <s.CTAVideo aria-label="This is a video with subtitles, on how to use this page.">
       <ReactPlayer
+      aria-hidden="true"
         url={video}
         width="100%"
         height="100%"
@@ -57,9 +58,9 @@ const HeroCTA: FC<HeroCtaProps> = ({
           }
         }}
         playIcon={
-          <Box className="play-button">
+          <Box className="play-button" role="button" aria-label="Play">
             <a href="#play-how-to-video">
-              <PlaySymbol />
+              <PlaySymbol/>
             </a>
           </Box>
         }

--- a/client/src/components/layout/Header/components/AuxiliaryNav/AuxiliaryNav.styled.tsx
+++ b/client/src/components/layout/Header/components/AuxiliaryNav/AuxiliaryNav.styled.tsx
@@ -2,18 +2,19 @@ import { styled } from 'theme/utils';
 import { Stack } from '@mui/material';
 import Button from 'components/Button';
 import { Link } from 'react-router-dom';
-import { ReactComponent as HomeIcon } from '../../../../../assets/icons/home.svg';
+import { Search } from '@mui/icons-material';
 
 export const StyledLink = styled(Link)`
   display: flex;
   align-items: center;
+  text-decoration: none !important;
 `;
 
-export const StyledHomeIcon = styled(HomeIcon)`
+export const StyledSearchIcon = styled(Search)`
   height: 30px;
   width: 30px;
   color: ${(props) => props.theme.palette.primary.main};
-  margin-right: ${(props) => (props.isLoggedIn ? '16px' : '32px')};
+ 
 `;
 
 export const Aux = styled(Stack)`
@@ -50,4 +51,11 @@ export const AuxButton = styled(Button)`
   color: ${(props) => props.theme.palette.primary.light};
   border-color: ${(props) => props.theme.palette.primary.dark};
   padding: 8px 24px;
+`;
+
+export const AuxContent = styled('text')`
+  font-weight: 500;
+  color: ${(props) => props.theme.palette.primary.light};
+  margin-right: ${(props) => (props.isLoggedIn ? '16px' : '32px')};
+  padding: 8px 10px;
 `;

--- a/client/src/components/layout/Header/components/AuxiliaryNav/AuxiliaryNav.tsx
+++ b/client/src/components/layout/Header/components/AuxiliaryNav/AuxiliaryNav.tsx
@@ -48,8 +48,9 @@ const AuxiliaryNav = () => {
   return (
     <s.Aux component="nav" direction="row" alignItems="center" spacing={2}>
       {!isSmallScreen && (
-        <s.StyledLink aria-label="Button to go to Search Page" to="/search">
-          <s.StyledHomeIcon isLoggedIn={isLoggedIn} />
+        <s.StyledLink aria-label="Button to go to the Search Page" to="/search">
+          <s.StyledSearchIcon titleaccess="Search Icon" />
+          <s.AuxContent component="h1" isLoggedIn={isLoggedIn}>Content</s.AuxContent>
         </s.StyledLink>
       )}
 
@@ -72,7 +73,7 @@ const AuxiliaryNav = () => {
         aria-controls={open ? menuId : undefined}
         aria-haspopup="true"
         aria-expanded={open ? 'true' : undefined}
-        aria-label="Open Main Menu"
+        aria-label="Open Site Menu"
       >
         <MoreVertIcon />
       </s.AuxMenuTrigger>

--- a/client/src/pages/Search/Search.tsx
+++ b/client/src/pages/Search/Search.tsx
@@ -12,11 +12,12 @@ const Home = () => {
   const languageSearchTerm = queryParams.get('language');
 
   return (
-    <Box>
+    <Box aria-label='Search Page'>
       <HeroPanelHome />
       <CategorizedContent
         tagSearchTerm={searchTerm || ''}
         languageSearchTerm={languageSearchTerm || ''}
+        aria-label='search cube commons content'
       />
       <Footer />
     </Box>

--- a/client/src/pages/Search/components/CategorizedContent/CategorizedContent.tsx
+++ b/client/src/pages/Search/components/CategorizedContent/CategorizedContent.tsx
@@ -169,6 +169,7 @@ const CategorizedContent = ({
             categoryFilter={categoryFilter}
             setCategoryFilter={setCategoryFilter}
             tagSearchTerm={tagSearchTerm || languageSearchTerm}
+            aria-label='filter search results using this menu'
           />
 
           {(categoryFilter === 'all' ||
@@ -182,19 +183,20 @@ const CategorizedContent = ({
                   </Typography>
                   {!isPlaylistLoading && playlistResults.length === 0 && (
                     <Grid>
-                      <Typography component="p" variant="body1" mt={2}>
+                      <Typography component="p" variant="body1" mt={2} aria-label='error message'>
                         <span>No playlists found/ aucun playlists trouvé</span>
                       </Typography>
                     </Grid>
                   )}
                 </Grid>
               </s.ContentHeader>
-              <s.Content>
+              <s.Content aria-label='a horizontal grid of Playlist cover images and titles'>
                 {isPlaylistLoading ? (
                   <Lottie
                     className="loading-cubes"
                     animationData={LoadingCubes}
                     loop={true}
+                    aria-label='loading icon'
                   />
                 ) : error ? (
                   <p>{error}</p>
@@ -211,7 +213,7 @@ const CategorizedContent = ({
                 )}
 
                 {!isPlaylistLoading && hasMorePlaylistToLoad && (
-                  <s.LoadMore onClick={handlePlaylistLoadMore}>
+                  <s.LoadMore onClick={handlePlaylistLoadMore} aria-label='button to load more'>
                     <span className="inner">
                       <span className="label">{t('Load More | Charger Plus')}</span>
                     </span>

--- a/client/src/pages/Search/components/HeroPanelHome/HeroPanelHome.tsx
+++ b/client/src/pages/Search/components/HeroPanelHome/HeroPanelHome.tsx
@@ -12,7 +12,7 @@ const HeroPanelHome = () => {
   return (
     <s.HeroPanelHome>
       <s.Bg>
-        <img src={HeroHome} alt="hero" width="100%" height="auto" />
+        <img src={HeroHome} alt="black and white background showing a person drawing" width="100%" height="auto" />
       </s.Bg>
 
       <s.Content>
@@ -22,7 +22,7 @@ const HeroPanelHome = () => {
               <Typography component="h1" variant="h1">
                 {t('searchPage')}
               </Typography>
-              <Typography component="h3" variant="h3">
+              <Typography component="h2" variant="h3" aria-label="French translation">
                 {t('searchPageFR')}
               </Typography>
             </s.Headline>

--- a/client/src/pages/Search/components/TagOfTheWeek/TagOfTheWeek.tsx
+++ b/client/src/pages/Search/components/TagOfTheWeek/TagOfTheWeek.tsx
@@ -78,8 +78,8 @@ const Content = () => {
     <s.ContentWrapper>
       <s.ContentHeader container>
         <Grid xs={10} xsOffset={1} md={5} mdOffset={1}>
-          <Typography component="h3" variant="h3">
-            <span>{t('featuredTag')}</span>
+          <Typography component="h3" variant="h3" aria-label="featured content">
+            <span aria-label="Tagged">{t('featuredTag')}</span>
           </Typography>
         </Grid>
       </s.ContentHeader>


### PR DESCRIPTION
Based on feedback from Org users, the search bar was obvious to someone looking at the page. And the "home" icon was confusing for those looking to search content.  By including the familiar search icon, we hope to increase how easy it is to see the search bar on the search page, and navigation to search content. 

This page also got significant aria-label updates to improve landmarks on the page and the experience of screen readers looking through content results. 