### PR TITLE
Issue #407 changes to terms of service updates

### DIFF
--- a/client/src/components/Legal/LegalModalNav.tsx
+++ b/client/src/components/Legal/LegalModalNav.tsx
@@ -12,6 +12,7 @@ import {
 import { useTranslation } from 'react-i18next';
 import * as s from './Legal.styled';
 import ToS from './ToS';
+import ToSFr from './ToSFr';
 import * as DarkContent from 'components/DarkContent.styled';
 
 const BootstrapDialog = styled(Dialog)(({ theme }) => ({
@@ -54,17 +55,23 @@ function BootstrapDialogTitle(props: DialogTitleProps) {
 }
 
 const LegalModalNav = () => {
-  const { t } = useTranslation();
   const [legalDisplay, setLegalDisplay] = useState(false);
-
+  const [isFrench, setIsFrench] = useState(false);
+  const { t } = useTranslation();
   return (
     <>
-      <s.NavLink onClick={() => setLegalDisplay(true)}>
+        <s.NavLink onClick={() => {
+        setIsFrench(false);
+        setLegalDisplay(true);
+      }} aria-haspopup="dialog" lang="en"> 
         {t(
           'Our Code of Conduct is Defined by our Terms of Service and Privacy Policy'
         )}
       </s.NavLink>
-      <s.NavLink onClick={() => setLegalDisplay(true)}>
+      <s.NavLink onClick={() => {
+        setIsFrench(true);
+        setLegalDisplay(true);
+      }} aria-haspopup="dialog" lang="fr"> 
         {t(
           'Notre code de conduite est défini par nos conditions d`utilisation et notre politique de confidentialité.'
         )}
@@ -83,7 +90,7 @@ const LegalModalNav = () => {
         </BootstrapDialogTitle>
         <DialogContent dividers>
           <DarkContent.Wrapper>
-            <ToS />
+          {isFrench ? <ToSFr /> : <ToS />}
           </DarkContent.Wrapper>
         </DialogContent>
         <DialogActions>

--- a/client/src/components/Legal/ToS.tsx
+++ b/client/src/components/Legal/ToS.tsx
@@ -52,13 +52,15 @@ const ToS = () => {
       </p>
       <h5>2.4. Profile Content</h5>
       <p>
-        You retain copyright and other rights you have in your Profile. By
-        submitting material to your Profile, you grant us a worldwide,
-        non-exclusive, perpetual, irrevocable, royalty-free, assignable,
-        transferable, and sub-licensable license to use, access, store,
-        reproduce, adapt, translate, publish, publicly perform or display,
-        modify, repost, create derivative works from, and distribute such
-        material in connection with our providing the Cube Services.
+        You retain copyright and other rights you have in your Profile. By submitting material to your Profile, you grant us a worldwide, non-exclusive, perpetual, irrevocable, royalty-free, assignable, transferable, and sub-licensable license to access, store, reproduce, translate, publish, publicly display, and distribute such material in connection with our providing the CubeCommons services.
+        Users retain full ownership of their uploaded content. CubeCommons will only use Profile Content for its primary function—audience viewing—unless the user explicitly opts in or provides written consent for additional uses.
+        Institutional users may designate (“Categories of Use”) to specify permitted and restricted actions, including but not limited to:</p>
+        <p>
+          <li>Cropping, text overlay, or any modifications to images, videos, or sound.</li>
+        <li>Use of content in marketing or promotional materials.</li> 
+        <li>Context-specific restrictions, such as exhibition-only use.</li>
+        </p> 
+        <p>Institutional users are responsible for ensuring that any uploaded content complies with their own loan agreements, artist contracts, or third-party restrictions. CubeCommons is not liable for any disputes arising from a user’s failure to comply with such agreements. Users may remove their content at any time or request the removal of content from marketing materials by emailing <a href="mailto:ash@cubecommons.ca">ash @ cubecommons.ca</a> will make reasonable efforts to comply with removal requests in a timely manner.
       </p>
       <h5>2.5. Responsibility</h5>
       <p>
@@ -66,6 +68,13 @@ const ToS = () => {
         your Profile. You, and not Cube Commons, are responsible for ensuring
         that all material in your Profile is accurate, lawful, and does not
         infringe or violate anyone’s rights or our Code of Conduct.
+      </p>
+      <p>
+      Users are responsible for ensuring they have the necessary rights and permissions to upload content. CubeCommons will not alter, use, or promote content beyond its agreed-upon use, except for general platform visibility, which may include an image or short screen recording showing the CubeCommons Search page or Profile pages in marketing and promotional materials.
+      CubeCommons is not liable for any claims, disputes, or legal actions resulting from a user’s failure to comply with existing artist contracts, licensing agreements, or other third-party obligations.
+      </p>
+      <p>
+      In cases where users or institutional members require content removal from marketing or promotional materials, they may submit a request to <a href="mailto:ash@cubecommons.ca">ash @ cubecommons.ca</a>. CubeCommons will make every effort to comply with such requests promptly.
       </p>
       <h5>2.6. Minors</h5>
       <p>
@@ -141,7 +150,7 @@ const ToS = () => {
         If you believe a Community Member, Creator, or Content is in violation
         of the Code of Conduct, or that Content has not been rated
         appropriately, you can report it to us by email
-        <a href="mailto:ash@cubecommons.ca">ash@cubecommons.ca</a>. Cube Commons
+        <a href="mailto:ash@cubecommons.ca">ash @ cubecommons.ca</a>. Cube Commons
         reviews all Reports and keeps records of steps taken to address them.
       </p>
       <h5>4.4. Response</h5>
@@ -510,7 +519,7 @@ const ToS = () => {
         a person under the age of 13, please contact us
       </h5>
       <p>
-        <a href="mailto:ash@cubecommons.ca">ash@cubecommons.ca</a>
+        <a href="mailto:ash@cubecommons.ca">ash @ cubecommons.ca</a>
       </p>
       <h4>8. User Rights</h4>
       <h5>8.1. Rights to Access and Correction</h5>
@@ -520,7 +529,7 @@ const ToS = () => {
         us to correct it. If you ask us to delete it, we will delete it
         entirely. If you want to see the personal information we have stored
         about you, you can make a request by email to:{' '}
-        <a href="mailto:ash@cubecommons.ca">ash@cubecommons.ca</a>
+        <a href="mailto:ash@cubecommons.ca">ash @ cubecommons.ca</a>
       </p>
       <h5>8.2. Right to Withdraw Consent and Right to Erasure</h5>
       <p>

--- a/client/src/components/Legal/ToSFr.tsx
+++ b/client/src/components/Legal/ToSFr.tsx
@@ -52,13 +52,18 @@ const ToSFr = () => {
         </p>
         <h5>2.4. Contenu du profil</h5>
         <p>
-          Vous conservez les droits d&apos;auteur et autres droits que vous avez sur votre Profil. En
-          soumettant du matériel à votre Profil, vous nous accordez une licence mondiale,
-          non exclusive, perpétuelle, irrévocable, libre de redevances, cessible,
-          transférable et pouvant faire l&apos;objet d&apos;une sous-licence pour utiliser, accéder, stocker,
-          reproduire, adapter, traduire, publier, exécuter ou afficher publiquement,
-          modifier, republier, créer des œuvres dérivées et distribuer ce
-          matériel en relation avec notre fourniture des services Cube.
+        Vous conservez les droits d&apos;auteur et autres droits sur votre Profil. En soumettant du contenu sur votre Profil, vous nous accordez une licence mondiale, non exclusive, perpétuelle, irrévocable, libre de droits, cessible, transférable et sous-licenciable pour accéder, stocker, reproduire, traduire, publier, afficher publiquement et distribuer ce contenu dans le cadre de la fourniture des services CubeCommons. 
+        Les utilisateurs conservent l&apos;entière propriété du contenu qu&apos;ils téléchargent. CubeCommons n&apos;utilisera le Contenu du Profil que pour sa fonction principale (le visionnage), sauf si l&apos;utilisateur y consent explicitement ou donne son consentement écrit pour des utilisations supplémentaires. Les utilisateurs institutionnels peuvent désigner des (&quot;Catégories d&apos;utilisation &quot;) pour préciser les actions autorisées et restreintes, y compris, mais sans s&apos;y limiter:</p>
+        <p> 
+          <li>Recadrage, superposition de texte ou toute modification d&apos;images, de vidéos ou de sons;</li>
+
+          <li>Utilisation du contenu dans des supports marketing ou promotionnels;</li>
+
+          <li>Restrictions spécifiques au contexte, telles que l&apos;utilisation en exposition uniquement.</li>
+        </p>
+      <p>
+      Les utilisateurs institutionnels sont responsables de la conformité de tout contenu téléchargé avec leurs propres accords de prêt, contrats d&apos;artiste ou restrictions de tiers. CubeCommons décline toute responsabilité en cas de litige découlant du non-respect de ces accords par un utilisateur. 
+      Les utilisateurs peuvent supprimer leur contenu à tout moment ou demander la suppression de contenu de leurs supports marketing en envoyant un courriel à <a href="mailto:ash@cubecommons.ca">ash @ cubecommons.ca</a>. CubeCommons fera tout son possible pour répondre aux demandes de suppression dans les meilleurs délais.
         </p>
         <h5>2.5. Responsabilité</h5>
         <p>
@@ -66,6 +71,12 @@ const ToSFr = () => {
           votre Profil. Vous, et non Cube Commons, êtes responsable de vous assurer
           que tout le matériel dans votre Profil est exact, légal et n&apos;enfreint pas
           ou ne viole pas les droits de quiconque ou notre Code de conduite.
+        </p>
+        <p>
+        Les utilisateurs sont responsables de s&apos;assurer qu&apos;ils disposent des droits et autorisations nécessaires pour téléverser du contenu. CubeCommons ne modifiera, n&apos;utilisera ni ne promouvra le contenu au-delà de l&apos;usage convenu, à l&apos;exception de la visibilité générale sur la plateforme, ce qui peut inclure une image ou un court enregistrement d&apos;écran montrant la page de recherche ou les pages de profil de CubeCommons dans les supports marketing et promotionnels. 
+        CubeCommons décline toute responsabilité en cas de réclamation, de litige ou de poursuite judiciaire résultant du non-respect par un utilisateur des contrats d&apos;artiste, des accords de licence ou d&apos;autres obligations de tiers en vigueur.
+        </p>
+        <p>Si les utilisateurs ou les membres institutionnels souhaitent que du contenu soit retiré de leurs supports marketing ou promotionnels, ils peuvent en faire la demande à <a href="mailto:ash@cubecommons.ca">ash @ cubecommons.ca</a>. CubeCommons mettra tout en œuvre pour accéder rapidement à ces demandes.
         </p>
         <h5>2.6. Mineurs</h5>
         <p>
@@ -127,7 +138,7 @@ const ToSFr = () => {
           Si vous pensez qu&apos;un Membre de la communauté, un Créateur ou un Contenu
           enfreint le Code de conduite, ou qu&apos;un Contenu n&apos;a pas été classé de
           manière appropriée, vous pouvez nous le signaler par email
-          <a href="mailto:ash@cubecommons.ca">ash@cubecommons.ca</a>. Cube Commons
+          <a href="mailto:ash@cubecommons.ca">ash @ cubecommons.ca</a>. Cube Commons
           examine tous les Signalements et conserve des enregistrements des mesures
           prises pour y répondre.
         </p>

--- a/client/src/components/Legal/ToSFr.tsx
+++ b/client/src/components/Legal/ToSFr.tsx
@@ -1,0 +1,157 @@
+const ToSFr = () => {
+    return (
+      <>
+        <h2>Conditions d&apos;utilisation</h2>
+        <h3>Dernière mise à jour : 30 novembre 2023</h3>
+        <h4>1. Introduction</h4>
+        <h4>
+          1.1 Acceptation des conditions : Ces conditions d&apos;utilisation, y compris notre code de
+          conduite (&quot;Code de
+        </h4>
+        <h4>
+          1.2 Modifications des conditions : Nous pouvons modifier les conditions, y compris la
+          politique de confidentialité, à
+        </h4>
+        <h4>
+          1.3 Politique de confidentialité : Votre utilisation des services Cube et toute information
+          que vous soumettez en utilisant le
+        </h4>
+        <h4>
+          1.4 Conditions supplémentaires : Ces conditions contiennent des sections qui s&apos;appliquent aux
+          participants du Cube
+        </h4>
+        <h4>
+          1.5 Définitions : Les mots en majuscules dans ces conditions ont les définitions
+          qui leur sont données dans ces
+        </h4>
+        <h4>2. Création de compte</h4>
+        <h5>2.1. Création de compte</h5>
+        <p>
+          Vous devez créer un compte pour utiliser certains services Cube et devenir
+          membre (&quot;Membre de la communauté&quot;) de notre communauté (&quot;Communauté Cube&quot;). Gardez
+          votre compte sécurisé et protégez votre mot de passe. Vous êtes responsable des
+          actions de toute personne utilisant votre compte, que vous ayez autorisé cette
+          utilisation ou non. Pour les particuliers, votre compte, y compris votre nom d&apos;utilisateur
+          et votre mot de passe, vous sont uniques et ne doivent être partagés avec personne.
+          Pour les organisations, votre compte, y compris votre nom d&apos;utilisateur et votre mot de passe,
+          ne doit pas être partagé avec quiconque en dehors de votre organisation.
+        </p>
+        <h5>2.2. Email du compte</h5>
+        <p>
+          Vous devez fournir une adresse email valide lors de votre inscription.
+          Tous les avis que nous devons vous envoyer seront envoyés à l&apos;adresse email
+          associée à votre compte.
+        </p>
+        <h5>2.3. Profil</h5>
+        <p>
+          Vous pouvez créer un profil à utiliser dans la Communauté Cube, comprenant un
+          nom, une photo, un lien et un petit bloc de texte (&quot;Profil&quot;). Les profils
+          ne doivent pas nécessairement être sous votre nom légal, mais doivent être conformes
+          à notre Code de conduite. Un Profil n&apos;est pas requis pour utiliser les services Cube, mais
+          est requis pour devenir Créateur.
+        </p>
+        <h5>2.4. Contenu du profil</h5>
+        <p>
+          Vous conservez les droits d&apos;auteur et autres droits que vous avez sur votre Profil. En
+          soumettant du matériel à votre Profil, vous nous accordez une licence mondiale,
+          non exclusive, perpétuelle, irrévocable, libre de redevances, cessible,
+          transférable et pouvant faire l&apos;objet d&apos;une sous-licence pour utiliser, accéder, stocker,
+          reproduire, adapter, traduire, publier, exécuter ou afficher publiquement,
+          modifier, republier, créer des œuvres dérivées et distribuer ce
+          matériel en relation avec notre fourniture des services Cube.
+        </p>
+        <h5>2.5. Responsabilité</h5>
+        <p>
+          Vous comprenez que vous êtes seul responsable de tout le matériel ajouté à
+          votre Profil. Vous, et non Cube Commons, êtes responsable de vous assurer
+          que tout le matériel dans votre Profil est exact, légal et n&apos;enfreint pas
+          ou ne viole pas les droits de quiconque ou notre Code de conduite.
+        </p>
+        <h5>2.6. Mineurs</h5>
+        <p>
+          La Communauté Cube est destinée aux adultes. Les personnes de moins de 18 ans
+          (&quot;Mineurs&quot;) ne sont pas autorisées à créer un compte sans le consentement écrit
+          d&apos;un parent ou tuteur. Les Mineurs peuvent utiliser les services Cube
+          sans compte, mais ne peuvent pas accéder au contenu qui n&apos;est pas classé &quot;Tout public&quot;.
+        </p>
+        <h4>3. Propriété intellectuelle</h4>
+        <h5>3.1. Application</h5>
+        <p>
+          Cette Section 3 s&apos;applique au contenu affiché au public via les
+          services Cube. Les conditions pour les Créateurs qui téléchargent du Contenu se trouvent
+          dans la section 8 (Contrat Créateur).
+        </p>
+        <h5>3.2. Droits réservés</h5>
+        <p>
+          Les services Cube et le contenu affiché sur les services Cube (&quot;Contenu&quot;)
+          sont notre propriété ou celle des ayants droit du contenu spécifique. Cube
+          Commons et les ayants droit dont le contenu est affiché via les services
+          Cube se réservent tous les droits de propriété intellectuelle, y compris,
+          sans limitation, les droits d&apos;auteur, marques de commerce, noms de domaine,
+          droits de conception, brevets et toute autre propriété intellectuelle de
+          quelque nature que ce soit, qu&apos;elle soit enregistrée ou non enregistrée
+          partout dans le monde.
+        </p>
+        <h5>3.3. Utilisation du contenu</h5>
+        <p>
+          Cube Commons autorise votre utilisation du Contenu et des services Cube
+          pour votre usage personnel dans le contexte des services Cube. Vous pouvez,
+          à des fins non commerciales, télécharger, diffuser, extraire ou acquérir
+          autrement (collectivement, &quot;Extraire&quot;) les métadonnées du Contenu affiché
+          sur les services Cube, y compris les informations d&apos;attribution ou autres
+          informations descriptives, liens vers le Contenu, et sous-titres ou fichiers VTT.
+          Vous ne pouvez pas Extraire le Contenu stocké sur d&apos;autres sites, ou le Contenu
+          d&apos;Accessibilité fourni par des fournisseurs tiers de services d&apos;accessibilité,
+          y compris, mais sans s&apos;y limiter, les traductions en langue des signes par
+          Deaf Spectrum ou d&apos;autres traductions linguistiques, sans le consentement écrit
+          préalable exprès de Cube Commons.
+        </p>
+        <h4>4. Politiques Cube</h4>
+        <h5>4.1. Code de conduite</h5>
+        <p>
+          Toute utilisation des services Cube est soumise à notre Code de conduite
+          cubecommons.ca. Le Code de conduite vise à maintenir les services Cube
+          sûrs et accueillants pour tous.
+        </p>
+        <h5>4.2. Classification du contenu</h5>
+        <p>
+          Cube Commons héberge une grande variété de Contenu, et tout n&apos;est pas
+          approprié pour les Mineurs. Nos Créateurs classent leur Contenu comme
+          &quot;Tout public&quot; ou &quot;Mature&quot; lors de son téléchargement. Le contenu classé
+          &quot;Tout public&quot; est approprié pour tous. Il peut être consulté par toute
+          personne utilisant les services Cube. Le contenu &quot;Mature&quot; est destiné aux
+          personnes de 18 ans et plus.
+        </p>
+        <h5>4.3. Signalements</h5>
+        <p>
+          Si vous pensez qu&apos;un Membre de la communauté, un Créateur ou un Contenu
+          enfreint le Code de conduite, ou qu&apos;un Contenu n&apos;a pas été classé de
+          manière appropriée, vous pouvez nous le signaler par email
+          <a href="mailto:ash@cubecommons.ca">ash@cubecommons.ca</a>. Cube Commons
+          examine tous les Signalements et conserve des enregistrements des mesures
+          prises pour y répondre.
+        </p>
+        <h5>4.4. Réponse</h5>
+        <p>
+          Cube Commons se réserve le droit de prendre toutes les mesures que nous
+          jugeons nécessaires pour faire respecter nos Conditions, y compris notre
+          Code de conduite. Cube Commons peut, sans limitation, suspendre des comptes,
+          supprimer des Profils ou des parties de Profils, supprimer des Listes de
+          lecture, ou supprimer ou masquer du Contenu si, à notre seule discrétion,
+          nous estimons que de telles mesures sont nécessaires.
+        </p>
+        <h4>5. Avertissements</h4>
+        <h5>5.1. Contenu</h5>
+        <p>
+          Les services Cube affichent du Contenu fourni par les Créateurs. Toutes
+          les déclarations ou opinions exprimées dans le Contenu sont uniquement
+          les opinions et la responsabilité des Créateurs qui possèdent le Contenu.
+          Ce Contenu ne reflète pas nécessairement l&apos;opinion de Cube Commons, et
+          nous ne sommes pas responsables envers vous ou tout tiers pour le Contenu,
+          les informations ou les opinions exprimées dans le Contenu.
+        </p>
+      </>
+    );
+  };
+  
+  export default ToSFr;

--- a/client/src/components/layout/Footer/Footer.tsx
+++ b/client/src/components/layout/Footer/Footer.tsx
@@ -109,7 +109,7 @@ const Footer = () => {
 
       <Grid container>
         <Grid xs={10} xsOffset={1} md={4}>
-          <s.Credits>
+          <s.Credits role="img">
             <CreditsImg />
           </s.Credits>
         </Grid>


### PR DESCRIPTION
Resolves #407 by New Media Gallery passed via vote by the CubeCommons Community of Gov4git. This update restricts how CubeCommons can use content on the platform for promotional purposes. Currently permissions will be requested and granted via email. However, when the upload page is updated, a checkbox will be added to grant specific marketing permissions for a piece of content. Otherwise, the updated Terms of Service will apply to any content without permissions indicated.

This update will be applied retroactively to all content on CubeCommons.